### PR TITLE
Add number entities for Parameter.Inverter.AcALim and .WMax

### DIFF
--- a/custom_components/smaev/number.py
+++ b/custom_components/smaev/number.py
@@ -14,7 +14,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfTime
+from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfTime, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -79,8 +79,27 @@ NUMBER_DESCRIPTIONS: tuple[SmaEvChargerNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_registry_enabled_default=True,
     ),
+    SmaEvChargerNumberEntityDescription(
+        key="charge_current_limit",
+        translation_key="charge_current_limit",
+        type=SMAEV_PARAMETER,
+        channel="Parameter.Inverter.AcALim",
+        native_step=1,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        entity_registry_enabled_default=True,
+    ),
+    SmaEvChargerNumberEntityDescription(
+        key="charge_power_limit",
+        translation_key="charge_power_limit",
+        type=SMAEV_PARAMETER,
+        channel="Parameter.Inverter.WMax",
+        native_step=1,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        entity_registry_enabled_default=True,
+    ),
 )
-
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/smaev/number.py
+++ b/custom_components/smaev/number.py
@@ -14,7 +14,13 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfTime, UnitOfElectricCurrent, UnitOfPower
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfEnergy,
+    UnitOfTime,
+    UnitOfElectricCurrent,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -100,6 +106,7 @@ NUMBER_DESCRIPTIONS: tuple[SmaEvChargerNumberEntityDescription, ...] = (
         entity_registry_enabled_default=True,
     ),
 )
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/smaev/number.py
+++ b/custom_components/smaev/number.py
@@ -93,7 +93,7 @@ NUMBER_DESCRIPTIONS: tuple[SmaEvChargerNumberEntityDescription, ...] = (
         native_step=1,
         mode=NumberMode.BOX,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        entity_registry_enabled_default=True,
+        entity_registry_enabled_default=False,
     ),
     SmaEvChargerNumberEntityDescription(
         key="charge_power_limit",
@@ -103,7 +103,7 @@ NUMBER_DESCRIPTIONS: tuple[SmaEvChargerNumberEntityDescription, ...] = (
         native_step=1,
         mode=NumberMode.BOX,
         native_unit_of_measurement=UnitOfPower.WATT,
-        entity_registry_enabled_default=True,
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/custom_components/smaev/number.py
+++ b/custom_components/smaev/number.py
@@ -14,7 +14,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfTime, UnitOfElectricCurrent
+from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfTime, UnitOfElectricCurrent, UnitOfPower
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/smaev/strings.json
+++ b/custom_components/smaev/strings.json
@@ -53,6 +53,12 @@
       },
       "energy_charge_session": {
         "name": "Energy quantity of the charge session"
+      },
+      "charge_current_limit": {
+        "name": "AC current limitation"
+      },
+      "charge_power_limit": {
+        "name": "Active power limit"
       }
     },
     "select": {

--- a/custom_components/smaev/translations/de.json
+++ b/custom_components/smaev/translations/de.json
@@ -53,6 +53,12 @@
       },
       "standby_charge_disconnect": {
         "name": "Ladebereitschaft bis Trennung"
+      },
+      "charge_current_limit": {
+        "name": "AC-Strom Begrenzung"
+      },
+      "charge_power_limit": {
+        "name": "Leistungsbegrenzung"
       }
     },
     "select": {

--- a/custom_components/smaev/translations/en.json
+++ b/custom_components/smaev/translations/en.json
@@ -53,6 +53,12 @@
       },
       "energy_charge_session": {
         "name": "Energy quantity of the charge session"
+      },
+      "charge_current_limit": {
+        "name": "AC current limitation"
+      },
+      "charge_power_limit": {
+        "name": "Active power limit"
       }
     },
     "select": {


### PR DESCRIPTION
This is an PR to implement feature from issue #5. It adds two more number entities to control the maximum current and or the maximum power charged to your car.