### PR TITLE
Forced refresh task is handled in correct event loop

### DIFF
--- a/custom_components/smaev/datetime.py
+++ b/custom_components/smaev/datetime.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     for entity_description in DATETIME_DESCRIPTIONS:
         entities.append(
             SmaEvChargerDateTime(
-                coordinator, config_entry.unique_id, device_info, entity_description
+                hass, coordinator, config_entry, device_info, entity_description
             )
         )
 
@@ -82,17 +82,19 @@ class SmaEvChargerDateTime(CoordinatorEntity, DateTimeEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         coordinator: DataUpdateCoordinator,
-        config_entry_unique_id: str,
+        config_entry: ConfigEntry,
         device_info: DeviceInfo,
         entity_description: SmaEvChargerDateTimeEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
+        self.hass = hass
         self.entity_description = entity_description
 
         self._attr_device_info = device_info
-        self._attr_unique_id = f"{config_entry_unique_id}-{self.entity_description.key}"
+        self._attr_unique_id = f"{config_entry.unique_id}-{self.entity_description.key}"
         self._attr_native_value = None
 
     @callback

--- a/custom_components/smaev/sensor.py
+++ b/custom_components/smaev/sensor.py
@@ -216,7 +216,7 @@ async def async_setup_entry(
     for entity_description in SENSOR_DESCRIPTIONS:
         entities.append(
             SmaEvChargerSensor(
-                coordinator, config_entry.unique_id, device_info, entity_description
+                hass, coordinator, config_entry, device_info, entity_description
             )
         )
 
@@ -231,17 +231,19 @@ class SmaEvChargerSensor(CoordinatorEntity, SensorEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         coordinator: DataUpdateCoordinator,
-        config_entry_unique_id: str,
+        config_entry: ConfigEntry,
         device_info: DeviceInfo,
         entity_description: SmaEvChargerSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
+        self.hass = hass
         self.entity_description = entity_description
 
         self._attr_device_info = device_info
-        self._attr_unique_id = f"{config_entry_unique_id}-{self.entity_description.key}"
+        self._attr_unique_id = f"{config_entry.unique_id}-{self.entity_description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/smaev/switch.py
+++ b/custom_components/smaev/switch.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     for entity_description in SWITCH_DESCRIPTIONS:
         entities.append(
             SmaEvChargerSwitch(
-                coordinator, config_entry.unique_id, device_info, entity_description
+                hass, coordinator, config_entry, device_info, entity_description
             )
         )
 
@@ -101,17 +101,19 @@ class SmaEvChargerSwitch(CoordinatorEntity, SwitchEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         coordinator: DataUpdateCoordinator,
-        config_entry_unique_id: str,
+        config_entry: ConfigEntry,
         device_info: DeviceInfo,
         entity_description: SmaEvChargerSwitchEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
+        self.hass = hass
         self.entity_description = entity_description
 
         self._attr_device_info = device_info
-        self._attr_unique_id = f"{config_entry_unique_id}-{self.entity_description.key}"
+        self._attr_unique_id = f"{config_entry.unique_id}-{self.entity_description.key}"
         self._attr_current_option = None
 
         self.inv_value_mapping = {


### PR DESCRIPTION
Refreshing select and number entities used the wrong event loop.
This PR fixes this issue.