### PR TITLE
Map charging session status 200115 and handle unknown enum values gracefully

### DIFF
--- a/custom_components/smaev/manifest.json
+++ b/custom_components/smaev/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/alengwenus/ha-sma-ev-charger/issues",
   "requirements": [
-    "pysmaev==0.1.9"
+    "pysmaev==0.1.10"
   ],
   "ssdp": [],
   "version": "1.3.0",

--- a/custom_components/smaev/sensor.py
+++ b/custom_components/smaev/sensor.py
@@ -140,8 +140,7 @@ SENSOR_DESCRIPTIONS: tuple[SmaEvChargerSensorEntityDescription, ...] = (
             SmaEvChargerMeasurements.SLEEP_MODE: "sleep_mode",
             SmaEvChargerMeasurements.ACTIVE_MODE: "active_mode",
             SmaEvChargerMeasurements.STATION_LOCKED: "station_locked",
-            # Use the raw value until pysmaev ships STATION_FAULT (alengwenus/pysmaev#9)
-            200115: "station_fault",
+            SmaEvChargerMeasurements.STATION_FAULT: "station_fault",
         },
         device_class=SensorDeviceClass.ENUM,
         options=[

--- a/custom_components/smaev/sensor.py
+++ b/custom_components/smaev/sensor.py
@@ -140,9 +140,16 @@ SENSOR_DESCRIPTIONS: tuple[SmaEvChargerSensorEntityDescription, ...] = (
             SmaEvChargerMeasurements.SLEEP_MODE: "sleep_mode",
             SmaEvChargerMeasurements.ACTIVE_MODE: "active_mode",
             SmaEvChargerMeasurements.STATION_LOCKED: "station_locked",
+            SmaEvChargerMeasurements.STATION_FAULT: "station_fault",
         },
         device_class=SensorDeviceClass.ENUM,
-        options=["not_connected", "sleep_mode", "active_mode", "station_locked"],
+        options=[
+            "not_connected",
+            "sleep_mode",
+            "active_mode",
+            "station_locked",
+            "station_fault",
+        ],
         entity_registry_enabled_default=True,
     ),
     SmaEvChargerSensorEntityDescription(
@@ -246,6 +253,7 @@ class SmaEvChargerSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{config_entry.unique_id}-{self.entity_description.key}"
+        self._unknown_value_reported: int | str | None = None
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -265,6 +273,24 @@ class SmaEvChargerSensor(CoordinatorEntity, SensorEntity):
             value = str(parameters_channel[SMAEV_VALUE])
 
         value = self.entity_description.value_mapping.get(value) or value
+
+        if (
+            self.entity_description.device_class == SensorDeviceClass.ENUM
+            and self.entity_description.options is not None
+            and value not in self.entity_description.options
+        ):
+            # An unmapped enum value would raise a ValueError in every
+            # coordinator update, spamming the log and freezing all entities
+            # of this device. Report it once and mark the sensor unknown.
+            if value != self._unknown_value_reported:
+                _LOGGER.warning(
+                    "Unknown value %s for %s. Please report this at "
+                    "https://github.com/alengwenus/ha-sma-ev-charger/issues",
+                    value,
+                    self.entity_id,
+                )
+                self._unknown_value_reported = value
+            value = None
 
         self._attr_native_value = value
         super()._handle_coordinator_update()

--- a/custom_components/smaev/sensor.py
+++ b/custom_components/smaev/sensor.py
@@ -140,7 +140,8 @@ SENSOR_DESCRIPTIONS: tuple[SmaEvChargerSensorEntityDescription, ...] = (
             SmaEvChargerMeasurements.SLEEP_MODE: "sleep_mode",
             SmaEvChargerMeasurements.ACTIVE_MODE: "active_mode",
             SmaEvChargerMeasurements.STATION_LOCKED: "station_locked",
-            SmaEvChargerMeasurements.STATION_FAULT: "station_fault",
+            # Use the raw value until pysmaev ships STATION_FAULT (alengwenus/pysmaev#9)
+            200115: "station_fault",
         },
         device_class=SensorDeviceClass.ENUM,
         options=[

--- a/custom_components/smaev/strings.json
+++ b/custom_components/smaev/strings.json
@@ -144,7 +144,8 @@
           "not_connected": "Not connected",
           "sleep_mode": "In sleep mode",
           "active_mode": "In active mode",
-          "station_locked": "Charging station locked"
+          "station_locked": "Charging station locked",
+          "station_fault": "Charging station fault"
         }
       },
       "connected_vehicle_status": {

--- a/custom_components/smaev/translations/de.json
+++ b/custom_components/smaev/translations/de.json
@@ -117,7 +117,8 @@
           "active_mode": "Ladevorgang aktiv",
           "not_connected": "nicht verbunden",
           "sleep_mode": "schlafend",
-          "station_locked": "Ladestation gesperrt"
+          "station_locked": "Ladestation gesperrt",
+          "station_fault": "Störung der Ladestation"
         }
       },
       "connected_vehicle_status": {

--- a/custom_components/smaev/translations/en.json
+++ b/custom_components/smaev/translations/en.json
@@ -151,7 +151,8 @@
           "not_connected": "Not connected",
           "sleep_mode": "In sleep mode",
           "active_mode": "In active mode",
-          "station_locked": "Charging station locked"
+          "station_locked": "Charging station locked",
+          "station_fault": "Charging station fault"
         }
       },
       "connected_vehicle_status": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "mypy>=1.20.2",
-    "pysmaev==0.1.9",
+    "pysmaev==0.1.10",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -941,7 +941,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mypy", specifier = ">=1.20.2" },
-    { name = "pysmaev", specifier = "==0.1.9" },
+    { name = "pysmaev", specifier = "==0.1.10" },
 ]
 
 [package.metadata.requires-dev]
@@ -1882,14 +1882,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c
 
 [[package]]
 name = "pysmaev"
-version = "0.1.9"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/1a/bf493d49135801aab1b0b0a036135f0c202b5c3b8c438e9c46280d771e4a/pysmaev-0.1.9.tar.gz", hash = "sha256:33de213ef482977f2261d4b782b8bf29b036530b4c711819147020c41c93f9d2", size = 9216, upload-time = "2026-05-14T10:52:03.476Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bb/43b22bc3e73b3eda2630b2554b0b630cd12a562b8dba19bb46ddb8d11f65/pysmaev-0.1.10.tar.gz", hash = "sha256:0f1f73ba604beddc82cb0e35ea91f9b0e2bd295ee97c4c30e8749f6be52d4f04", size = 9296, upload-time = "2026-07-12T06:40:51.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/8c/02a32252f0af2ec7c07f5bbc21cc6841dd1fe2d8cb698fd5e0cab794d7d9/pysmaev-0.1.9-py3-none-any.whl", hash = "sha256:ac59cb0006a9756e1a856b3b05bb793cb43595f60c6c9175a45dae52c626b81d", size = 7175, upload-time = "2026-05-14T10:52:02.282Z" },
+    { url = "https://files.pythonhosted.org/packages/19/11/9a28002afff977f0ba45eece488c38cb82576111392ba37cb48951247295/pysmaev-0.1.10-py3-none-any.whl", hash = "sha256:23f023669865e0c2efb4fffc26c0f1d3c5de609379701bc118c93bccd1269223", size = 7278, upload-time = "2026-07-12T06:40:50.157Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When my SMA EV Charger 22 (EVC22-3AC-20, firmware 2.6.37.R) entered a fault state (red LED after the charging cable had not been locked properly), it reported the charging session status value `200115`. The integration raised `ValueError: Sensor ... provides state value '200115', which is not in the list of options` in every coordinator update. This spammed the log every 5 seconds and left all entities of the device frozen for hours until the cable was replugged.

This PR contains two changes:

1. Maps `200115` to a new `station_fault` state (English and German translations included). Depends on alengwenus/pysmaev#9 which adds `STATION_FAULT = 200115`.
2. Makes enum sensors robust against future unknown values: instead of letting Home Assistant raise on an unmapped value, the sensor logs a single warning (asking to report the value) and becomes `unknown`, while all other entities keep updating.

See evcc-io/evcc#13108 for another report of `200115` as a fault state.
